### PR TITLE
adding infrastructure_component_id to CloudBroker

### DIFF
--- a/micado_types.yaml
+++ b/micado_types.yaml
@@ -201,6 +201,9 @@ node_types:
       opened_port:
         type: string
         required: false
+      infrastructure_component_id:
+        type: string
+        required: false
     interfaces:
       Occopus:
         type: tosca.interfaces.MiCADO.Occopus


### PR DESCRIPTION
adding properties infrastructure_component_id to CloudBroker node type in micado_type file.