### PR TITLE
Sleep Healthcare Demonstrator ADT 

### DIFF
--- a/ADT/sleep/4-update-adt.sh
+++ b/ADT/sleep/4-update-adt.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+settings_file="./_settings"
+
+. $settings_file
+
+echo "Updating $APP_ID in MiCADO at $MICADO_MASTER..."
+curl --insecure -s -F file=@"$ADT_FILENAME" -X PUT -u "$SSL_USER":"$SSL_PASS" https://$MICADO_MASTER:$MICADO_PORT/toscasubmitter/v1.0/app/update/$APP_ID | jq

--- a/ADT/sleep/sleep-sse_ec2.yaml
+++ b/ADT/sleep/sleep-sse_ec2.yaml
@@ -25,7 +25,7 @@ dsl_definitions:
         create:
           inputs:
             endpoint: https://ec2.eu-west-2.amazonaws.com
-
+ 
 topology_template:
   node_templates:
 
@@ -65,8 +65,18 @@ topology_template:
             type: tosca.relationships.AttachesTo
             properties:
               location: /data/xnat/home/logs
-      - volume: xnat-archive-vol
-      - volume: xnat-build-vol
+      - volume:
+          node: xnat-archive-vol
+          relationship:
+            type: tosca.relationships.AttachesTo
+            properties:
+              location: /data/xnat/archive
+      - volume:
+          node: xnat-build-vol
+          relationship:
+            type: tosca.relationships.AttachesTo
+            properties:
+              location: /data/xnat/build
       - volume: docker-socket-vol
 
     xnat-db:
@@ -95,7 +105,6 @@ topology_template:
       type: tosca.nodes.MiCADO.Container.Application.Docker.Deployment
       properties:
         image: somnonetz/snet-nginx
-        args: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
         env:
           - name: XNAT_API_URL
             value:
@@ -114,8 +123,18 @@ topology_template:
           hostPort: 443
       requirements:
       - host: sleep-app-server
-      - volume: letsencrypt-vol
-      - volume: certbot-vol
+      - volume:
+          node: letsencrypt-vol
+          relationship:
+            type: tosca.relationships.AttachesTo
+            properties:
+              location: /etc/letsencrypt
+      - volume:
+          node: certbot-vol
+          relationship:
+            type: tosca.relationships.AttachesTo
+            properties:
+              location: /var/www/certbot
       - volume: 
           node: nginx-conf-vol
           relationship:
@@ -127,12 +146,20 @@ topology_template:
       type: tosca.nodes.MiCADO.Container.Application.Docker.Deployment
       properties:
         image: certbot/certbot
-        command: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
       requirements:
       - host: sleep-app-server
-      - volume: letsencrypt-vol
-      - volume: certbot-vol
-      - host: cq-server
+      - volume:
+          node: letsencrypt-vol
+          relationship:
+            type: tosca.relationships.AttachesTo
+            properties:
+              location: /etc/letsencrypt
+      - volume:
+          node: certbot-vol
+          relationship:
+            type: tosca.relationships.AttachesTo
+            properties:
+              location: /var/www/certbot
 
     # Describe volumes
     xnat-logs-vol:
@@ -158,11 +185,11 @@ topology_template:
     letsencrypt-vol:
       type: tosca.nodes.MiCADO.Container.Volume.HostPath
       properties:
-        path: /etc/letsencrypt
+        path: /data/certbot/conf
     certbot-vol:
       type: tosca.nodes.MiCADO.Container.Volume.HostPath
       properties:
-        path: /var/www/certbot
+        path: /data/certbot/www
     nginx-conf-vol:
       type: tosca.nodes.MiCADO.Container.Volume.HostPath
       properties:

--- a/ADT/sleep/sleep-sse_ec2.yaml
+++ b/ADT/sleep/sleep-sse_ec2.yaml
@@ -25,7 +25,27 @@ dsl_definitions:
         create:
           inputs:
             endpoint: https://ec2.eu-west-2.amazonaws.com
- 
+
+  compute_cloud_with_nfs: &compute_cloud_with_nfs
+    type: tosca.nodes.MiCADO.EC2.Compute
+    properties:
+      region_name: ADD_YOUR_REGION_NAME_HERE (e.g. eu-west-1)
+      image_id: ADD_YOUR_IMAGE_ID_HERE (e.g. ami-061a2d878e5754b62)
+      instance_type: ADD_INSTANCE_TYPE_HERE (e.g. t2.small)
+      security_group_ids:
+        - ADD_YOUR_SECURITY_GROUP_ID_HERE (e.g. sg-93d46bf7)
+      key_name: -OPTIONAL- ADD_YOUR_KEY_NAME_HERE (e.g. my_ssh_key)
+      context:
+        insert: true
+        cloud_config: |
+          runcmd:
+          - apt-get install -y nfs-common
+    interfaces:
+      Occopus:
+        create:
+          inputs:
+            endpoint: https://ec2.eu-west-2.amazonaws.com
+
 topology_template:
   node_templates:
 
@@ -97,7 +117,7 @@ topology_template:
       requirements:
       - host: sleep-app-server
       - volume: 
-          node: postgres-vol
+          node: xnat-db-vol
           relationship:
             type: tosca.relationships.AttachesTo
             properties:
@@ -126,13 +146,13 @@ topology_template:
       requirements:
       - host: sleep-app-server
       - volume:
-          node: letsencrypt-vol
+          node: certbot-conf-vol
           relationship:
             type: tosca.relationships.AttachesTo
             properties:
               location: /etc/letsencrypt
       - volume:
-          node: certbot-vol
+          node: certbot-www-vol
           relationship:
             type: tosca.relationships.AttachesTo
             properties:
@@ -144,58 +164,66 @@ topology_template:
             properties:
               location: /etc/nginx/conf.d
 
-    certbot:
-      type: tosca.nodes.MiCADO.Container.Application.Docker.Deployment
-      properties:
-        image: certbot/certbot
-      requirements:
-      - host: sleep-app-server
-      - volume:
-          node: letsencrypt-vol
-          relationship:
-            type: tosca.relationships.AttachesTo
-            properties:
-              location: /etc/letsencrypt
-      - volume:
-          node: certbot-vol
-          relationship:
-            type: tosca.relationships.AttachesTo
-            properties:
-              location: /var/www/certbot
+    # certbot:
+    #   type: tosca.nodes.MiCADO.Container.Application.Docker.Deployment
+    #   properties:
+    #     image: certbot/certbot
+    #   requirements:
+    #   - host: sleep-app-server
+    #   - volume:
+    #       node: certbot-conf-vol
+    #       relationship:
+    #         type: tosca.relationships.AttachesTo
+    #         properties:
+    #           location: /etc/letsencrypt
+    #   - volume:
+    #       node: certbot-www-vol
+    #       relationship:
+    #         type: tosca.relationships.AttachesTo
+    #         properties:
+    #           location: /var/www/certbot
 
     # Describe volumes
     xnat-logs-vol:
-      type: tosca.nodes.MiCADO.Container.Volume.HostPath
+      type: tosca.nodes.MiCADO.Container.Volume.NFS
       properties:
-        path: /data/xnat/logs
+        server: 172.31.24.144
+        path: /home/ubuntu/nfs/xnat/logs
     xnat-archive-vol:
-      type: tosca.nodes.MiCADO.Container.Volume.HostPath
+      type: tosca.nodes.MiCADO.Container.Volume.NFS
       properties:
-        path: /data/xnat/archive
+        server: 172.31.24.144
+        path: /home/ubuntu/nfs/xnat/archive
     xnat-build-vol:
-      type: tosca.nodes.MiCADO.Container.Volume.HostPath
+      type: tosca.nodes.MiCADO.Container.Volume.NFS
       properties:
-        path: /data/xnat/build
+        server: 172.31.24.144
+        path: /home/ubuntu/nfs/xnat/build
+    xnat-db-vol:
+      type: tosca.nodes.MiCADO.Container.Volume.NFS
+      properties:
+        server: 172.31.24.144
+        path: /home/ubuntu/nfs/xnat-db
+    nginx-conf-vol:
+      type: tosca.nodes.MiCADO.Container.Volume.NFS
+      properties:
+        server: 172.31.24.144
+        path: /home/ubuntu/nfs/nginx/conf.d
+    certbot-conf-vol:
+      type: tosca.nodes.MiCADO.Container.Volume.NFS
+      properties:
+        server: 172.31.24.144
+        path: /home/ubuntu/nfs/certbot/conf
+    certbot-www-vol:
+      type: tosca.nodes.MiCADO.Container.Volume.NFS
+      properties:
+        server: 172.31.24.144
+        path: /home/ubuntu/nfs/certbot/www
     docker-socket-vol:
       type: tosca.nodes.MiCADO.Container.Volume.HostPath
       properties:
         path: /var/run/docker.sock
-    postgres-vol:
-      type: tosca.nodes.MiCADO.Container.Volume.HostPath
-      properties:
-        path: /data/xnat-db
-    letsencrypt-vol:
-      type: tosca.nodes.MiCADO.Container.Volume.HostPath
-      properties:
-        path: /data/certbot/conf
-    certbot-vol:
-      type: tosca.nodes.MiCADO.Container.Volume.HostPath
-      properties:
-        path: /data/certbot/www
-    nginx-conf-vol:
-      type: tosca.nodes.MiCADO.Container.Volume.HostPath
-      properties:
-        path: /data/nginx/conf.d
+
 
     # Describe the SSE containers
     sse:
@@ -299,7 +327,7 @@ topology_template:
       - host: ta-server
 
     # Describe server VMs
-    sleep-app-server: *compute_cloud
+    sleep-app-server: *compute_cloud_with_nfs
     sse-server: *compute_cloud
     ta-server: *compute_cloud
       

--- a/ADT/sleep/sleep-sse_ec2.yaml
+++ b/ADT/sleep/sleep-sse_ec2.yaml
@@ -36,26 +36,27 @@ topology_template:
         image: somnonetz/snet-xnat
         env:
         - name: XNAT_ROOT
-          value:
+          value: /data/xnat
         - name: XNAT_HOME
-          value:
+          value: /data/xnat/home
         - name: XNAT_DATASOURCE_DRIVER
-          value:
+          value: org.postgresql.Driver
         - name: XNAT_DATASOURCE_URL
-          value:
+          value: jdbc:postgresql://xnat-db/xnat
         - name: XNAT_DATASOURCE_USERNAME
-          value:
+          value: xnat
         - name: XNAT_DATASOURCE_PASSWORD
-          value:
+          value: ADD_YOUR_XNAT_DB_PASSWORD_HERE
         - name: XNAT_HIBERNATE_DIALECT
-          value:
+          value: org.hibernate.dialect.PostgreSQL9Dialect
         - name: TOMCAT_XNAT_FOLDER
-          value:
+          value: xnat
         - name: CATALINA_OPTS
-          value: -Xms128m -Xmx2048m -Dxnat.home= -agentlib:jdwp=transport=dt_socket=dt_socket,server=y,suspend=n,address=8000
+          value: -Xms128m -Xmx2048m -Dxnat.home=/data/xnat/home -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
         - name: PGPASSWORD
-          value:
+          value: ADD_YOUR_XNAT_DB_PASSWORD_HERE
         ports:
+        - target: 8080 
         - containerPort: 8080
       requirements:
       - host: sleep-app-server
@@ -85,12 +86,13 @@ topology_template:
         image: postgres:9.4-alpine
         env:
           - name: POSTGRES_USER
-            value:
+            value: xnat
           - name: POSTGRES_PASSWORD
-            value:
+            value: ADD_YOUR_XNAT_DB_PASSWORD_HERE
           - name: POSTGRES_DB
-            value:
+            value: xnat
         ports:
+        - target: 5432
         - containerPort: 5432
       requirements:
       - host: sleep-app-server
@@ -107,15 +109,15 @@ topology_template:
         image: somnonetz/snet-nginx
         env:
           - name: XNAT_API_URL
-            value:
+            value: https://xnat.snet-apps.com/xnat/REST
           - name: SSE_SERVER_BASE_URL
-            value:
+            value: https://sse.snet-apps.com
           - name: TA_BASE_URL
-            value:
+            value: https://ta.snet-apps.com
           - name: SALT_VALUE
-            value:
+            value: abc123!?
           - name: IV_VALUE
-            value:
+            value: abcdefg
         ports:
         - containerPort: 80
           hostPort: 80


### PR DESCRIPTION
This PR contains the following updates to the definitions in `ADT/sleep`:

* Disable certbot (for now)
* Remove inline entry-points for nginx, this was causing the ADT to be rejected.
* Add missing environment variables
* Set target port on xnat and xnat-db
* Change HostPath volumes to NFS volumes for persistence
